### PR TITLE
ci: add codeowners template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Please include the (team) name of the codeowner(s) below following the syntax guidance in the github documentation for automatic peer reviewer assignment and ease to identify the owner
+# [github documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
+*

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Please include the (team) name of the codeowner(s) below following the syntax guidance in the github documentation for automatic peer reviewer assignment and ease to identify the owner
 # [github documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
-*
+* @stevenkang90


### PR DESCRIPTION
### Why?
An up to date and accurate codeowners file is requirement for the Github Security Standard that was enforced on January 8th 2024.
 This PR has been raised by the Product Security Engineering team as no CODEOWNERS file was found in this repository. The benefit of the CODEOWNERS file is to be able to easily identify who owns this code and enables automatic peer reviewer assignment when a PR is raised.

"A CODEOWNERS file must be included within the repository and contain at least 1
Codeowner or member of the relevant codeowning team or group. The codeowner(s)
must be justifiable based on the codeowner's direct involvement in the repository" - Github Security Standard

Alternatively, this repository can be archived by making a request in [#repo_lost-and-found](https://deliveroo.slack.com/archives/C0494K9E52T)
---

## What you need to do (How to review)?
Currently the CODEOWNERS is blank.
1. Please edit the file to add in the name of the codeowner(s)
2. Merge the PR

 If this PR was raised by mistake and a CODEOWNERS file is not needed, feel free to close this PR.

---
### Further info

Guidance on the syntax is included in the [github CODEOWNERS Documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)

### [JIRA: PSC-824](https://deliveroo.atlassian.net/browse/PSC-824?atlOrigin=eyJpIjoiNDdlZjE0MDA2YzczNGQ0N2EwMjc4NWM3MjQ1NGRkYTgiLCJwIjoiaiJ9)

### [#Github-Security-Standard](https://deliveroo.slack.com/archives/C065VP6LQAF)

### [Github Security Standard Documents and FAQ](https://deliveroo.atlassian.net/wiki/spaces/PSC/pages/4364206099/Github+Security+Standard+ft.+branch+protection)